### PR TITLE
Overwrite config variables

### DIFF
--- a/lib/capistrano/maintenance.rb
+++ b/lib/capistrano/maintenance.rb
@@ -5,9 +5,9 @@ module Capistrano::Maintenance
   def self.load_into(configuration)
     configuration.load do
 
-      _cset(:maintenance_dirname) { "#{shared_path}/system" }
-      _cset :maintenance_basename, "maintenance"
-      _cset(:maintenance_template_path) { File.join(File.dirname(__FILE__), "templates", "maintenance.html.erb") }
+      set(:maintenance_dirname) { "#{shared_path}/system" }
+      set :maintenance_basename, "maintenance"
+      set(:maintenance_template_path) { File.join(File.dirname(__FILE__), "templates", "maintenance.html.erb") }
 
       namespace :deploy do
 


### PR DESCRIPTION
Since newer version of capistrano sets the same variables, `_cset` are silently ignored and try to use capistrano's template, not capistrano-maintenance's one. (see https://github.com/capistrano/capistrano/pull/456 )

Assuming that `require 'capistrano/maintenance'` comes **before** setting those variables, this fix allows user to use capistrano-maintenance template by default.
