### PR TITLE
adds :put_via option that enables scp upload of the maint page

### DIFF
--- a/lib/capistrano/maintenance.rb
+++ b/lib/capistrano/maintenance.rb
@@ -69,7 +69,12 @@ module Capistrano::Maintenance
             template = File.read(maintenance_template_path)
             result = ERB.new(template).result(binding)
 
-            put result, "#{maintenance_dirname}/#{maintenance_basename}.html", :mode => 0644
+            put_options = { :mode => 0644 }
+            if fetch(:put_via)
+              put_options[:via] = fetch(:put_via)
+            end
+
+            put result, "#{maintenance_dirname}/#{maintenance_basename}.html", put_options
           end
 
           desc <<-DESC

--- a/lib/capistrano/maintenance.rb
+++ b/lib/capistrano/maintenance.rb
@@ -70,7 +70,7 @@ module Capistrano::Maintenance
             result = ERB.new(template).result(binding)
 
             put_options = { :mode => 0644 }
-            if fetch(:put_via)
+            if fetch(:put_via, false)
               put_options[:via] = fetch(:put_via)
             end
 


### PR DESCRIPTION
add :put_via option that enables upload of the maintenance page :via => :scp

'set :put_via', :scp will cause deploy:web:disable to put the maintenance page using scp
